### PR TITLE
Add better way to mention email address.

### DIFF
--- a/kubernetes-software-engineer.md
+++ b/kubernetes-software-engineer.md
@@ -74,7 +74,7 @@ If the Pull Request is approved, a final call to meet the team will be made and 
 
 ## How to apply
 
-Sending an email with your CV attached to `jobs [at] clastix.io`.
+Sending an email with your CV attached to [jobs@clastix.io](mailto:jobs@clastix.io).
 
 Please share your GitHub/BitBucket/GitLab profile with us, if you have one and you are contributing to open-source projects.
 


### PR DESCRIPTION
By using this method, individuals have the ability to easily apply through email. When the email address is right-clicked, the default email application from the system will be opened, and when left-clicked, there will be a one-click option to copy the email.